### PR TITLE
Support for Bootstrap 4 beta

### DIFF
--- a/examples/Bootstrap4/App.jsx
+++ b/examples/Bootstrap4/App.jsx
@@ -62,7 +62,7 @@ class Form extends React.Component {
           <FormControlInput type="email" id="username" name="username"
                             value={this.state.username} onChange={this.handleChange}
                             required minLength={3} />
-          <FieldFeedbacks for="username">
+          <FieldFeedbacks for="username" className="invalid-feedback">
             <FieldFeedback when="tooShort">Too short</FieldFeedback>
             <FieldFeedback when="*" />
           </FieldFeedbacks>
@@ -74,7 +74,7 @@ class Form extends React.Component {
                             innerRef={password => this.password = password}
                             value={this.state.password} onChange={this.handlePasswordChange}
                             required pattern=".{5,}" />
-          <FieldFeedbacks for="password" show="all">
+          <FieldFeedbacks for="password" show="all" className="invalid-feedback">
             <FieldFeedback when="valueMissing" />
             <FieldFeedback when="patternMismatch">Should be at least 5 characters long</FieldFeedback>
             <FieldFeedback when={value => !/\d/.test(value)} warning>Should contain numbers</FieldFeedback>
@@ -88,7 +88,7 @@ class Form extends React.Component {
           <FormControlLabel htmlFor="password-confirm">Confirm Password</FormControlLabel>
           <FormControlInput type="password" id="password-confirm" name="passwordConfirm"
                             value={this.state.passwordConfirm} onChange={this.handleChange} />
-          <FieldFeedbacks for="passwordConfirm">
+          <FieldFeedbacks for="passwordConfirm" className="invalid-feedback">
             <FieldFeedback when={value => value !== this.password.value}>Not the same password</FieldFeedback>
           </FieldFeedbacks>
         </FormGroup>

--- a/src/Bootstrap4.tsx
+++ b/src/Bootstrap4.tsx
@@ -41,13 +41,13 @@ export class FormGroup extends React.Component<FormGroupProps> {
     if (fieldName !== undefined) {
       const form = this.context.form;
       if (form.fieldsStore.containErrors(fieldName)) {
-        className += ' has-danger';
+        className += ' is-invalid has-danger';
       }
       else if (form.fieldsStore.containWarnings(fieldName)) {
-        className += ' has-warning';
+        className += ' is-invalid has-warning';
       }
       else if (form.fieldsStore.areValidDirtyWithoutWarnings(fieldName)) {
-        className += ' has-success';
+        className += ' is-valid has-success';
       }
     }
     return className;
@@ -110,13 +110,13 @@ export class FormControlInput extends React.Component<FormControlInputProps> {
     if (name !== undefined) {
       const form = this.context.form;
       if (form.fieldsStore.containErrors(name)) {
-        className += ' form-control-danger';
+        className += ' is-invalid form-control-danger';
       }
       else if (form.fieldsStore.containWarnings(name)) {
-        className += ' form-control-warning';
+        className += ' is-invalid form-control-warning';
       }
       else if (form.fieldsStore.areValidDirtyWithoutWarnings(name)) {
-        className += ' form-control-success';
+        className += ' is-valid form-control-success';
       }
     }
     return className;


### PR DESCRIPTION
Hi, I have a quick fix for Bootstrap 4 beta for validation styling. I still left there the old classes, because anything can change in bootstrap and for backward compatibility (Bootstrap 4 alpha).

You need to add class to FieldFeedbacks manually where you define all the rules (see example). I didn't want to add there the error class to the component.

Related to #9