### PR TITLE
Extend outer theme instead of creating a new one

### DIFF
--- a/examples/Bootstrap4/App.jsx
+++ b/examples/Bootstrap4/App.jsx
@@ -5,7 +5,7 @@ import 'raf/polyfill';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { isEqual, omit } from 'lodash';
+import { isEqual, omit } from 'lodash-es';
 
 import { FormWithConstraints, Input, FieldFeedbacks, Async, FieldFeedback } from 'react-form-with-constraints-bootstrap4';
 import { DisplayFields } from 'react-form-with-constraints-tools';

--- a/examples/Bootstrap4/index.html
+++ b/examples/Bootstrap4/index.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Example Bootstrap4</title>
-
-    <link rel="stylesheet" href="App.css">
   </head>
 
   <body>

--- a/examples/Bootstrap4/package.json
+++ b/examples/Bootstrap4/package.json
@@ -19,7 +19,7 @@
     "react": "latest",
     "react-dom": "latest",
 
-    "lodash": "latest",
+    "lodash-es": "latest",
 
     "react-form-with-constraints": "^0.10.0",
     "react-form-with-constraints-bootstrap4": "^0.10.0",

--- a/examples/Bootstrap4/package.json
+++ b/examples/Bootstrap4/package.json
@@ -16,6 +16,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest",
 

--- a/examples/Bootstrap4/package.json
+++ b/examples/Bootstrap4/package.json
@@ -46,7 +46,6 @@
     "style-loader": "latest",
     "css-loader": "latest",
     "sass-loader": "latest",
-    "mini-css-extract-plugin": "latest",
 
     "webpack-cli": "latest",
     "webpack": "latest",

--- a/examples/Bootstrap4/webpack.config.js
+++ b/examples/Bootstrap4/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
 
   module: {
     rules: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader' },
+      { test: /\.jsx?$/, loader: 'babel-loader' },
       { test: /\.js$/, loader: 'source-map-loader' },
       { test: /\.html$/, loader: 'file-loader', options: {name: '[path][name].[ext]'} },
       {

--- a/examples/Bootstrap4/webpack.config.js
+++ b/examples/Bootstrap4/webpack.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 const path = require('path');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   entry: {
@@ -13,10 +12,6 @@ module.exports = {
     filename: '[name].js'
   },
 
-  plugins: [
-    new MiniCssExtractPlugin({filename: '[name].css'})
-  ],
-
   resolve: {
     extensions: ['.js', '.jsx']
   },
@@ -27,11 +22,9 @@ module.exports = {
       { test: /\.js$/, loader: 'source-map-loader' },
       { test: /\.html$/, loader: 'file-loader', options: {name: '[path][name].[ext]'} },
       {
-        // FIXME Don't know how to make source maps work
-        // See SourceMap not working with Webpack 4.8.1 https://github.com/webpack-contrib/mini-css-extract-plugin/issues/141
         test: /\.scss$/,
         use: [
-          MiniCssExtractPlugin.loader,
+          { loader: 'style-loader', options: {sourceMap: true} },
           { loader: 'css-loader', options: {sourceMap: true} },
           { loader: 'sass-loader', options: {sourceMap: true} }
         ]

--- a/examples/ClubMembers/package.json
+++ b/examples/ClubMembers/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
 
+  "main": "App.tsx",
+
   "scripts": {
     "clean": "del-cli build",
 

--- a/examples/ClubMembers/package.json
+++ b/examples/ClubMembers/package.json
@@ -15,6 +15,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest",
 

--- a/examples/MaterialUI/package.json
+++ b/examples/MaterialUI/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
 
+  "main": "App.tsx",
+
   "scripts": {
     "clean": "del-cli build",
 

--- a/examples/MaterialUI/package.json
+++ b/examples/MaterialUI/package.json
@@ -15,6 +15,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest",
 

--- a/examples/NoFramework/package.json
+++ b/examples/NoFramework/package.json
@@ -15,6 +15,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest"
   },

--- a/examples/NoFramework/package.json
+++ b/examples/NoFramework/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
 
+  "main": "App.tsx",
+
   "scripts": {
     "clean": "del-cli build",
 

--- a/examples/Password/package.json
+++ b/examples/Password/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
 
+  "main": "App.tsx",
+
   "scripts": {
     "clean": "del-cli build",
 

--- a/examples/Password/package.json
+++ b/examples/Password/package.json
@@ -18,6 +18,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest",
 

--- a/examples/WizardForm/App.tsx
+++ b/examples/WizardForm/App.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import WizardForm from './WizardForm';
 
 import './index.html';
-import '../Password/style.css';
+import './style.css';
 
 const App = () => (
   <>

--- a/examples/WizardForm/package.json
+++ b/examples/WizardForm/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "private": true,
 
+  "main": "App.tsx",
+
   "scripts": {
     "clean": "del-cli build",
 

--- a/examples/WizardForm/package.json
+++ b/examples/WizardForm/package.json
@@ -15,6 +15,8 @@
   },
 
   "dependencies": {
+    "react-scripts": "latest",
+
     "react": "latest",
     "react-dom": "latest",
 

--- a/examples/WizardForm/style.css
+++ b/examples/WizardForm/style.css
@@ -1,0 +1,24 @@
+body {
+  background-color: lightgrey;
+}
+
+form > div {
+  margin-bottom: 10px;
+}
+
+form > div > label {
+  display: block;
+}
+
+[data-feedback].error {
+  color: red;
+}
+[data-feedback].warning {
+  color: orange;
+}
+[data-feedback].info {
+  color: blue;
+}
+[data-feedback].when-valid {
+  color: green;
+}

--- a/packages/react-form-with-constraints-material-ui/src/Material.tsx
+++ b/packages/react-form-with-constraints-material-ui/src/Material.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
   FormControl as _FormControl,
   TextField as _TextField,
-  MuiThemeProvider, createMuiTheme, Theme,
+  MuiThemeProvider, Theme,
   createStyles, withStyles, WithStyles
 } from '@material-ui/core';
 import { FormControlProps } from '@material-ui/core/FormControl';
@@ -138,7 +138,8 @@ export class TextField extends React.Component<TextFieldProps, TextFieldState> {
   }
 }
 
-const formWithConstraintsTheme = createMuiTheme({
+const formWithConstraintsTheme = (outer: Theme | null) => ({
+  ...outer,
   overrides: {
     MuiFormHelperText: {
       root: {


### PR DESCRIPTION
Use [theme nesting](https://material-ui.com/customization/overrides/#theme-nesting) instead of creating a new one. Otherwise, all outer styles will be lost.

Please note that TypeScript complains because of `Property 'shape' is missing in type '{ overrides: { MuiFormHelperText: { root: { '&:empty': { marginTop: number; minHeight: number; }; }; }; }; }'.`. Probably this is related to [typescript type widening](https://material-ui.com/guides/typescript/#using-createstyles-to-defeat-type-widening). 
I really think this should be fixed as otherwise, your build may break.